### PR TITLE
#16 Add support dataframes that contain maps

### DIFF
--- a/src/test/scala/za/co/absa/spark/hats/transformations/DeepArrayTransformationSuite.scala
+++ b/src/test/scala/za/co/absa/spark/hats/transformations/DeepArrayTransformationSuite.scala
@@ -882,7 +882,7 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase {
     assert(splitByDeepestParent("a.b", Seq("", "a")) == ("a", "b"))
   }
 
-  test("Test extended array transformations with an inner map") {
+  test("Test nested add column with an inner map") {
     val expectedSchema =
       """root
         | |-- name: string (nullable = true)
@@ -905,6 +905,94 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase {
 
     val df = nestedWithMapCaseFactory.getTestCase
     val dfOut = df.nestedWithColumn("addresses.planet", lit("Earth"))
+
+    val actualSchema = dfOut.schema.treeString
+    val actualResults = dfOut.toJSON.collect.mkString("\n")
+
+    assertSchema(actualSchema, expectedSchema)
+    assertResults(actualResults, expectedResults)
+  }
+
+  test("Test nested drop column with an inner map") {
+    val expectedSchema =
+      """root
+        | |-- name: string (nullable = true)
+        | |-- addresses: array (nullable = true)
+        | |    |-- element: struct (containsNull = false)
+        | |    |    |-- state: string (nullable = true)
+        | |-- properties: map (nullable = true)
+        | |    |-- key: string
+        | |    |-- value: string (valueContainsNull = true)
+        |""".stripMargin.replace("\r\n", "\n")
+    val expectedResults =
+      """{"name":"John","addresses":[{"state":"NY"},{"state":"NY"}],"properties":{"hair":"black","eyes":"brown","height":"178"}}
+        |{"name":"Kate","addresses":[{"state":"CA"},{"state":"CA"}],"properties":{"hair":"brown","eyes":"black","height":"165"}}
+        |{"name":"Michael","addresses":[{"state":"CA"},{"state":"CA"}],"properties":{"white":"black","eyes":"black","height":"180"}}
+        |{"name":"Sarah","properties":{"hair":"blond","eyes":"red","height":"162"}}
+        |{"name":"William","addresses":[{"state":"NV"}],"properties":{"hair":"red","eye":"gray","height":"185"}}"""
+        .stripMargin.replace("\r\n", "\n")
+
+    val df = nestedWithMapCaseFactory.getTestCase
+    val dfOut = df.nestedDropColumn("addresses.city")
+
+    val actualSchema = dfOut.schema.treeString
+    val actualResults = dfOut.toJSON.collect.mkString("\n")
+
+    assertSchema(actualSchema, expectedSchema)
+    assertResults(actualResults, expectedResults)
+  }
+
+  test("Test nested drop when dropping a map") {
+    val expectedSchema =
+      """root
+        | |-- name: string (nullable = true)
+        | |-- addresses: array (nullable = true)
+        | |    |-- element: struct (containsNull = true)
+        | |    |    |-- city: string (nullable = true)
+        | |    |    |-- state: string (nullable = true)
+        |""".stripMargin.replace("\r\n", "\n")
+    val expectedResults =
+      """{"name":"John","addresses":[{"city":"Newark","state":"NY"},{"city":"Brooklyn","state":"NY"}]}
+        |{"name":"Kate","addresses":[{"city":"San Jose","state":"CA"},{"city":"Sandiago","state":"CA"}]}
+        |{"name":"Michael","addresses":[{"city":"Sacramento","state":"CA"},{"city":"San Diego","state":"CA"}]}
+        |{"name":"Sarah"}
+        |{"name":"William","addresses":[{"city":"Las Vegas","state":"NV"}]}"""
+        .stripMargin.replace("\r\n", "\n")
+
+    val df = nestedWithMapCaseFactory.getTestCase
+    val dfOut = df.nestedDropColumn("properties")
+
+    val actualSchema = dfOut.schema.treeString
+    val actualResults = dfOut.toJSON.collect.mkString("\n")
+
+    assertSchema(actualSchema, expectedSchema)
+    assertResults(actualResults, expectedResults)
+  }
+
+  test("Test nested map column with an inner map") {
+    val expectedSchema =
+      """root
+        | |-- name: string (nullable = true)
+        | |-- addresses: array (nullable = true)
+        | |    |-- element: struct (containsNull = false)
+        | |    |    |-- city: string (nullable = true)
+        | |    |    |-- state: string (nullable = true)
+        | |    |    |-- city1: string (nullable = true)
+        | |-- properties: map (nullable = true)
+        | |    |-- key: string
+        | |    |-- value: string (valueContainsNull = true)
+        |""".stripMargin.replace("\r\n", "\n")
+    val expectedResults =
+      """{"name":"John","addresses":[{"city":"Newark","state":"NY","city1":"Newark1"},{"city":"Brooklyn","state":"NY","city1":"Brooklyn1"}],"properties":{"hair":"black","eyes":"brown","height":"178"}}
+        |{"name":"Kate","addresses":[{"city":"San Jose","state":"CA","city1":"San Jose1"},{"city":"Sandiago","state":"CA","city1":"Sandiago1"}],"properties":{"hair":"brown","eyes":"black","height":"165"}}
+        |{"name":"Michael","addresses":[{"city":"Sacramento","state":"CA","city1":"Sacramento1"},{"city":"San Diego","state":"CA","city1":"San Diego1"}],"properties":{"white":"black","eyes":"black","height":"180"}}
+        |{"name":"Sarah","properties":{"hair":"blond","eyes":"red","height":"162"}}
+        |{"name":"William","addresses":[{"city":"Las Vegas","state":"NV","city1":"Las Vegas1"}],"properties":{"hair":"red","eye":"gray","height":"185"}}"""
+        .stripMargin.replace("\r\n", "\n")
+
+    val df = nestedWithMapCaseFactory.getTestCase
+    val dfOut = df.nestedWithColumnExtended("addresses.city1",
+      gf => concat(gf("addresses.city"), lit("1") ))
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = dfOut.toJSON.collect.mkString("\n")

--- a/src/test/scala/za/co/absa/spark/hats/transformations/samples/NestedMapTestCaseFactory.scala
+++ b/src/test/scala/za/co/absa/spark/hats/transformations/samples/NestedMapTestCaseFactory.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spark.hats.transformations.samples
+
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Row, SparkSession, types}
+
+class NestedMapTestCaseFactory(implicit spark: SparkSession) {
+
+  private val testCaseSchema = new StructType()
+    .add("name", StringType)
+    .add("addresses", ArrayType(new StructType()
+      .add("city", StringType)
+      .add("state", StringType)))
+    .add("properties", MapType(StringType, StringType))
+
+  private val tstCaseData = Seq(
+    Row("John", List(Row("Newark", "NY"), Row("Brooklyn", "NY")), Map("hair" -> "black", "eyes" -> "brown", "height" -> "178")),
+    Row("Kate", List(Row("San Jose", "CA"), Row("Sandiago", "CA")), Map("hair" -> "brown", "eyes" -> "black", "height" -> "165")),
+    Row("William", List(Row("Las Vegas", "NV")), Map("hair" -> "red", "eye" -> "gray", "height" -> "185")),
+    Row("Sarah", null, Map("hair" -> "blond", "eyes" -> "red", "height" -> "162")),
+    Row("Michael", List(Row("Sacramento", "CA"), Row("San Diego", "CA")), Map("white" -> "black", "eyes" -> "black", "height" -> "180"))
+  )
+
+  def getTestCase: DataFrame = {
+    spark.createDataFrame(
+      spark.sparkContext.parallelize(tstCaseData),
+      testCaseSchema
+    ).orderBy("name")
+  }
+
+}


### PR DESCRIPTION
It seems that spark-hats already supports this. Just added unit tests.

Adding support to do transformations inside maps is something to be done in #15.