### PR TITLE
#35 - Add code coverage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ To use the extensions you need to add this import to your Spark application or s
 import za.co.absa.spark.hats.Extensions._
 ```
 
+### How to generate Code coverage report
+```sbt
+sbt jacoco
+```
+Code coverage will be generated on path:
+```
+{local-path}\spark-hats\target\scala-2.XY\jacoco\report\html
+```
+
+
 ## Motivation
 
 Here is a small example we will use to show you how `spark-hats` work. The important thing is that the dataframe

--- a/build.sbt
+++ b/build.sbt
@@ -48,3 +48,17 @@ lazy val hats = (project in file("."))
 // release settings
 releaseCrossBuild := true
 addCommandAlias("releaseNow", ";set releaseVersionBump := sbtrelease.Version.Bump.Bugfix; release with-defaults")
+
+// JaCoCo code coverage
+Test / jacocoReportSettings := JacocoReportSettings(
+  s"spark-hats Jacoco Report - ${scalaVersion.value}",
+  None,
+  JacocoThresholds(),
+  Seq(JacocoReportFormats.HTML, JacocoReportFormats.XML),
+  "utf-8")
+
+// exclude example
+Test / jacocoExcludes := Seq(
+//  "za.co.absa.spark.hats.transformations.NestedArrayTransformation*", // class and related objects
+//  "za.co.absa.spark.hats.transformations.ArrayContext" // class only
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,4 +17,5 @@
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "2.0.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.12")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "5.6.0")
+addSbtPlugin("com.github.sbt"    % "sbt-jacoco"    % "3.4.0")
 


### PR DESCRIPTION
- added new plugin dependency
- extended `readme.md` file with how to get code coverage report
- extended build logic to add JaCoCo non-default settings

Closes #35 