### PR TITLE
#35 - Add code coverage support improve

### DIFF
--- a/.github/workflows/jacoco_check.yml
+++ b/.github/workflows/jacoco_check.yml
@@ -37,11 +37,6 @@ jobs:
             spark: 2.4.8
             overall: 0.0
             changed: 80.0
-          - scala: 2.12.15
-            scalaShort: "2.12"
-            spark: 3.2.1
-            overall: 0.0
-            changed: 80.0
     name: Check code-coverage by JaCoCo - Spark ${{matrix.spark}} on Scala ${{matrix.scala}}
     steps:
       - name: Checkout code


### PR DESCRIPTION
- Removed Code coverage check for spark 3.

Reason: In team discussion decided that there is not add value. So let's safe remote run time.

Closes #35 