### PR TITLE
#38 Add scala 2.13 support

### DIFF
--- a/.github/workflows/jacoco_check.yml
+++ b/.github/workflows/jacoco_check.yml
@@ -32,9 +32,14 @@ jobs:
             spark: 2.4.8
             overall: 0.0
             changed: 80.0
-          - scala: 2.12.15
+          - scala: 2.12.18
             scalaShort: "2.12"
-            spark: 2.4.8
+            spark: 3.2.4
+            overall: 0.0
+            changed: 80.0
+          - scala: 2.13.11
+            scalaShort: "2.13"
+            spark: 3.4.1
             overall: 0.0
             changed: 80.0
     name: Check code-coverage by JaCoCo - Spark ${{matrix.spark}} on Scala ${{matrix.scala}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.11.12, 2.12.15]
-        spark: [2.4.8, 3.2.1]
+        scala: [2.11.12, 2.12.18, 2.13.11]
+        spark: [2.4.8, 3.2.4, 3.4.1]
         exclude:
           - scala: 2.11.12
-            spark: 3.2.1
+            spark: 3.2.4
+          - scala: 2.11.12
+            spark: 3.4.1
+          - scala: 2.12.18
+            spark: 2.4.8
+          - scala: 2.13.11
+            spark: 2.4.8
     name: Test Spark ${{matrix.spark}} on Scala ${{matrix.scala}}
     steps:
       - name: Checkout code

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "2.0.0")
-addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.12")
-addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "5.6.0")
+addSbtPlugin("com.github.sbt"    % "sbt-pgp"       % "2.2.1")
+addSbtPlugin("com.github.sbt"    % "sbt-release"   % "1.1.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "5.7.0")
 
 // sbt-jacoco - workaround related dependencies required to download
 lazy val ow2Version = "9.5"

--- a/src/main/scala/za/co/absa/spark/hats/transformations/NestedArrayTransformations.scala
+++ b/src/main/scala/za/co/absa/spark/hats/transformations/NestedArrayTransformations.scala
@@ -19,7 +19,7 @@ package za.co.absa.spark.hats.transformations
 import org.apache.spark.sql.functions.{array, callUDF, col, flatten, struct, when, concat}
 import org.apache.spark.sql.types.{ArrayType, DataType, StructField, StructType}
 import org.apache.spark.sql.{Column, DataFrame}
-import za.co.absa.spark.hofs._
+import za.co.absa.spark.hats.HofsWrapper._
 import za.co.absa.spark.hats.utils.SchemaUtils
 
 import scala.collection.mutable.ListBuffer

--- a/src/main/scala/za/co/absa/spark/hats/transformations/NestedArrayTransformations.scala
+++ b/src/main/scala/za/co/absa/spark/hats/transformations/NestedArrayTransformations.scala
@@ -453,7 +453,7 @@ object NestedArrayTransformations {
             throw new IllegalArgumentException(s"Not a struct field: $columnToUnstruct")
         }
         if (newColumn == null) {
-          mappedFields
+          mappedFields.toSeq
         } else {
           Seq(newColumn) ++ mappedFields
         }
@@ -848,7 +848,7 @@ object NestedArrayTransformations {
           handlePrimitive(dt, transformExpression, errorExpression, parentPath, arrCtx)
       }
       if (newColumn == null) {
-        mappedFields
+        mappedFields.toSeq
       } else {
         Seq(newColumn) ++ mappedFields
       }

--- a/src/main/scala_2.11/za/co/absa/spark/hats/HofsWrapper.scala
+++ b/src/main/scala_2.11/za/co/absa/spark/hats/HofsWrapper.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spark.hats
+
+import org.apache.spark.sql.Column
+
+import za.co.absa.spark.hofs.{transform => hofsTransform}
+
+/**
+  * This is a wrapper for high order functions depending on Scala version
+  */
+object HofsWrapper {
+  /**
+    * Applies the function `f` to every element in the `array`. The method is an equivalent to the `map` function
+    * from functional programming.
+    *
+    * @param array       A column of arrays
+    * @param f           A function transforming individual elements of the array
+    * @param elementName The name of the lambda variable. The value is used in Spark execution plans.
+    * @return A column of arrays with transformed elements
+    */
+  def transform(
+                 array: Column,
+                 f: Column => Column,
+                 elementName: String): Column = {
+    hofsTransform(array, f, elementName)
+  }
+}

--- a/src/main/scala_2.11/za/co/absa/spark/hats/HofsWrapper.scala
+++ b/src/main/scala_2.11/za/co/absa/spark/hats/HofsWrapper.scala
@@ -21,7 +21,9 @@ import org.apache.spark.sql.Column
 import za.co.absa.spark.hofs.{transform => hofsTransform}
 
 /**
-  * This is a wrapper for high order functions depending on Scala version
+  * This is a wrapper for high order functions depending on Scala version.
+  *
+  * This implementation uses Hofs(https://github.com/AbsaOSS/spark-hofs).
   */
 object HofsWrapper {
   /**

--- a/src/main/scala_2.12/za/co/absa/spark/hats/HofsWrapper.scala
+++ b/src/main/scala_2.12/za/co/absa/spark/hats/HofsWrapper.scala
@@ -20,7 +20,9 @@ import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions.{transform => sparkTransform}
 
 /**
-  * This is a wrapper for high order functions depending on Scala version
+  * This is a wrapper for high order functions depending on Scala version.
+  *
+  * This implementation uses native Spark transform().
   */
 object HofsWrapper {
   /**

--- a/src/main/scala_2.12/za/co/absa/spark/hats/HofsWrapper.scala
+++ b/src/main/scala_2.12/za/co/absa/spark/hats/HofsWrapper.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spark.hats
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions.{transform => sparkTransform}
+
+/**
+  * This is a wrapper for high order functions depending on Scala version
+  */
+object HofsWrapper {
+  /**
+    * Applies the function `f` to every element in the `array`. The method is an equivalent to the `map` function
+    * from functional programming.
+    *
+    * @param array       A column of arrays
+    * @param f           A function transforming individual elements of the array
+    * @param elementName The name of the lambda variable. The value is used in Spark execution plans.
+    * @return A column of arrays with transformed elements
+    */
+  def transform(
+                 array: Column,
+                 f: Column => Column,
+                 elementName: String): Column = {
+    sparkTransform(array, f)
+  }
+}

--- a/src/main/scala_2.13/za/co/absa/spark/hats/HofsWrapper.scala
+++ b/src/main/scala_2.13/za/co/absa/spark/hats/HofsWrapper.scala
@@ -16,10 +16,13 @@
 
 package za.co.absa.spark.hats
 
-import org.apache.spark.sql.{Column, functions => sparkTransform}
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions.{transform => sparkTransform}
 
 /**
-  * This is a wrapper for high order functions depending on Scala version
+  * This is a wrapper for high order functions depending on Scala version.
+  *
+  * This implementation uses native Spark transform().
   */
 object HofsWrapper {
   /**

--- a/src/main/scala_2.13/za/co/absa/spark/hats/HofsWrapper.scala
+++ b/src/main/scala_2.13/za/co/absa/spark/hats/HofsWrapper.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spark.hats
+
+import org.apache.spark.sql.{Column, functions => sparkTransform}
+
+/**
+  * This is a wrapper for high order functions depending on Scala version
+  */
+object HofsWrapper {
+  /**
+    * Applies the function `f` to every element in the `array`. The method is an equivalent to the `map` function
+    * from functional programming.
+    *
+    * @param array       A column of arrays
+    * @param f           A function transforming individual elements of the array
+    * @param elementName The name of the lambda variable. The value is used in Spark execution plans.
+    * @return A column of arrays with transformed elements
+    */
+  def transform(
+                 array: Column,
+                 f: Column => Column,
+                 elementName: String): Column = {
+    sparkTransform(array, f)
+  }
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,5 +1,4 @@
-#
-# Copyright 2019 ABSA Group Limited
+# Copyright 2020 ABSA Group Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +10,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-sbt.version=1.9.2
+log4j.rootCategory=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+log4j.appender.console.Threshold=ERROR

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -1,5 +1,4 @@
-#
-# Copyright 2019 ABSA Group Limited
+# Copyright 2020 ABSA Group Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +10,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-sbt.version=1.9.2
+log4j.rootCategory=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+log4j.appender.console.Threshold=ERROR

--- a/src/test/scala/za/co/absa/spark/hats/transformations/DeepArrayErrorTransformationSuite.scala
+++ b/src/test/scala/za/co/absa/spark/hats/transformations/DeepArrayErrorTransformationSuite.scala
@@ -19,14 +19,14 @@ package za.co.absa.spark.hats.transformations
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{IntegerType, StringType}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.slf4j.LoggerFactory
 import za.co.absa.spark.hats.SparkTestBase
 import za.co.absa.spark.hats.transformations.samples.DeepArraySamples._
 import za.co.absa.spark.hats.transformations.samples.SampleErrorUDFs
 import za.co.absa.spark.hats.utils.JsonUtils
 
-class DeepArrayErrorTransformationSuite extends FunSuite with SparkTestBase {
+class DeepArrayErrorTransformationSuite extends AnyFunSuite with SparkTestBase {
   // scalastyle:off line.size.limit
   // scalastyle:off null
 

--- a/src/test/scala/za/co/absa/spark/hats/transformations/DeepArrayTransformationSuite.scala
+++ b/src/test/scala/za/co/absa/spark/hats/transformations/DeepArrayTransformationSuite.scala
@@ -18,7 +18,7 @@ package za.co.absa.spark.hats.transformations
 
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StringType
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.slf4j.LoggerFactory
 import za.co.absa.spark.hats.SparkTestBase
 import za.co.absa.spark.hats.transformations.samples.DeepArraySamples._
@@ -30,7 +30,7 @@ import za.co.absa.spark.hats.transformations.samples.NestedMapTestCaseFactory
 // It is declared package private so the names won't pollute public/exported namespace
 
 
-class DeepArrayTransformationSuite extends FunSuite with SparkTestBase {
+class DeepArrayTransformationSuite extends AnyFunSuite with SparkTestBase {
   // scalastyle:off line.size.limit
   // scalastyle:off null
 

--- a/src/test/scala/za/co/absa/spark/hats/transformations/ExtendedTransformationsSuite.scala
+++ b/src/test/scala/za/co/absa/spark/hats/transformations/ExtendedTransformationsSuite.scala
@@ -19,13 +19,13 @@ package za.co.absa.spark.hats.transformations
 import org.apache.commons.io.IOUtils
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StringType
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.slf4j.LoggerFactory
 import za.co.absa.spark.hats.SparkTestBase
 import za.co.absa.spark.hats.transformations.samples.{ErrorMessage, NestedTestCaseFactory, SampleErrorUDFs}
 import za.co.absa.spark.hats.utils.JsonUtils
 
-class ExtendedTransformationsSuite extends FunSuite with SparkTestBase {
+class ExtendedTransformationsSuite extends AnyFunSuite with SparkTestBase {
   implicit val _: SampleErrorUDFs = new SampleErrorUDFs
 
   private val log = LoggerFactory.getLogger(this.getClass)

--- a/version.sbt
+++ b/version.sbt
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-version in ThisBuild := "0.2.3-SNAPSHOT"
+ThisBuild / version := "0.3.0-SNAPSHOT"


### PR DESCRIPTION
Added support for Scala 2.13 by selectively compile against hofs dependencies.

- Use hofs for Scala 2.11
- Use Spark transform() for Scala 2.12 and Scala 2.13